### PR TITLE
adjusted to fit the hashed password model in around version 1.7

### DIFF
--- a/user/plugins/shibboleth/plugin.php
+++ b/user/plugins/shibboleth/plugin.php
@@ -43,7 +43,8 @@ function shibboleth_is_valid_user() {
                 yourls_set_user( $_SERVER[SHIBBOLETH_UID] );
                 if ( !yourls_is_API() ) {
                         // Satisfy yourls' cookie generation routine
-                        $yourls_user_passwords[$_SERVER[SHIBBOLETH_UID]]=md5($_SERVER[SHIBBOLETH_UID]);
+                        $salt = rand( 10000, 99999 );
+                        $yourls_user_passwords[$_SERVER[SHIBBOLETH_UID]]='md5:' . $salt . ':' . md5($salt . $_SERVER[SHIBBOLETH_UID]);
                         yourls_store_cookie( YOURLS_USER );
                 }
                 return true;


### PR DESCRIPTION
A slight amendment so that the [`includes/functions-auth.php::yourls_has_cleartext_passwords()`](https://github.com/YOURLS/YOURLS/blob/fd938fd19742e141f95f14ef654d1501bdb63679/includes/functions-auth.php#L265) method works correctly for "Shibbolethised" users.

Specifically the [`includes/functions-auth.php::yourls_has_md5_password()`](https://github.com/YOURLS/YOURLS/blob/fd938fd19742e141f95f14ef654d1501bdb63679/includes/functions-auth.php#L285) method.

Without this I was getting the "Could not auto-encrypt passwords." message on the admin screen (which comes from [`includes/auth.php`](https://github.com/YOURLS/YOURLS/blob/fd938fd19742e141f95f14ef654d1501bdb63679/includes/auth.php#L53).