### PR TITLE
replace split() with explode()

### DIFF
--- a/user/plugins/shibboleth/rbac.php
+++ b/user/plugins/shibboleth/rbac.php
@@ -340,7 +340,7 @@ function shibboleth_rbac_environment_check() {
  */
 function shibboleth_rbac_cidr_match($ip, $range)
 {
-    list ($subnet, $bits) = split('/', $range);
+    list ($subnet, $bits) = explode('/', $range);
     $ip = ip2long($ip);
     $subnet = ip2long($subnet);
     $mask = -1 << (32 - $bits);


### PR DESCRIPTION
PHP7 does not support split().

With this fix, we have confirmed that it works in the environment of YOULRS 1.8.1 / php 7.4.
